### PR TITLE
Add section on cloud vendor support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,3 +543,14 @@ or
         <td><code>2</code></td>
     </tr>
 </table>
+
+# Cloud Vendor Support
+
+`pg_roaringbitmap` is supported by Alibaba Cloud RDS PostgreSQL: https://www.alibabacloud.com/help/doc-detail/142340.htm
+
+To request support for `pg_roaringbitmap` from other cloud vendors, please see the following:
+
+- Amazon RDS: send an email to rds-postgres-extensions-request@amazon.com with the extension name and use case ([docs](https://aws.amazon.com/rds/postgresql/faqs/))
+- Google Cloud SQL: comment on [this issue](https://issuetracker.google.com/u/1/issues/207403722)
+- DigitalOcean Managed Databases: comment on [this idea](https://ideas.digitalocean.com/app-framework-services/p/postgres-extension-request-pgroaringbitmap)
+- Azure Database for PostgreSQL: comment on [this post](https://feedback.azure.com/d365community/idea/e6f5ff90-da4b-ec11-a819-0022484bf651)


### PR DESCRIPTION
Thanks for a great extension 🙇 

We would like to adopt it, but we're prevented by lack of cloud vendor support. As such, I've added a section on how to show interest in cloud vendors supporting `pg_roaringbitmap`.