### PR TITLE
Add example demonstrating how to build and load the extension for the official postgres docker image

### DIFF
--- a/docker-example/Dockerfile
+++ b/docker-example/Dockerfile
@@ -1,0 +1,16 @@
+FROM postgres:16.0-bookworm AS builder
+ENV VERSION_TAG 0.5.4
+
+RUN apt-get update && apt-get install -y curl unzip make gcc postgresql-server-dev-16
+RUN curl -LO "https://github.com/ChenHuajun/pg_roaringbitmap/archive/refs/tags/v$VERSION_TAG.zip"
+RUN unzip "v$VERSION_TAG.zip"
+WORKDIR "pg_roaringbitmap-$VERSION_TAG"
+RUN make -f Makefile_native && make install
+
+FROM postgres:16.0-bookworm
+COPY --from=builder /usr/share/postgresql/16/extension/roaringbitmap* /usr/share/postgresql/16/extension
+COPY --from=builder /usr/lib/postgresql/16/lib/roaringbitmap.so /usr/lib/postgresql/16/lib
+COPY --from=builder /usr/lib/postgresql/16/lib/bitcode/roaringbitmap /usr/lib/postgresql/16/lib/bitcode/roaringbitmap
+COPY --from=builder /usr/lib/postgresql/16/lib/bitcode/roaringbitmap.index.bc /usr/lib/postgresql/16/lib/bitcode/roaringbitmap.index.bc
+
+COPY load-extension.sql /docker-entrypoint-initdb.d

--- a/docker-example/README.md
+++ b/docker-example/README.md
@@ -1,0 +1,20 @@
+# Building the extension with docker
+
+This directory contains an example showing you how to build and use the extension with the official postgres docker
+image.
+
+## Usage
+
+```shell
+docker compose up
+```
+
+After the container is started the extension is created automatically.
+
+### Verify working extension
+
+To verify that the extension is working correctly you can execute the following statment
+
+```sql
+SELECT roaringbitmap('{1,2,3}')
+```

--- a/docker-example/docker-compose.yml
+++ b/docker-example/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+    database:
+      build:
+        dockerfile: Dockerfile
+      environment:
+        - POSTGRES_USER=admin
+        - POSTGRES_PASSWORD=123456
+        - POSTGRES_DB=test
+      ports:
+        - "5432:5432"

--- a/docker-example/load-extension.sql
+++ b/docker-example/load-extension.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION roaringbitmap;


### PR DESCRIPTION
Hi, recently I had the use case that I needed to use the extension within the official postgres docker image.
As there is no adhoc way to load external extensions in a container, I thought of creating a small example demonstrating how to build and load this extension in a dockerized environment.

@ChenHuajun