### PR TITLE
Initialize rbitmap_output_format

### DIFF
--- a/roaringbitmap.c
+++ b/roaringbitmap.c
@@ -21,7 +21,7 @@ static const struct config_enum_entry output_format_options[] =
     {NULL, 0, false}
 };
 
-static int	rbitmap_output_format;		/* output format */
+static int	rbitmap_output_format = RBITMAP_OUTPUT_BYTEA;		/* output format */
 
 void		_PG_init(void);
 /*


### PR DESCRIPTION
On cassert-enabled PG builds, DefineCustomEnumVariable() was complaining that the configured "boot" value and the initial value of the GUC didn't match.

```
2024-03-19 16:29:16.319 CET [1768144] myon@contrib_regression LOG:  GUC (PGC_ENUM) roaringbitmap.output_format, boot_val=1, C-var=0
2024-03-19 16:29:16.319 CET [1768144] myon@contrib_regression STATEMENT:  CREATE EXTENSION if not exists roaringbitmap;
TRAP: failed Assert("check_GUC_init(variable)"), File: "./build/../src/backend/utils/misc/guc.c", Line: 4773, PID: 1768144
```