### PR TITLE
Add postgres 18 to build matrix

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg: [13, 14, 15, 16, 17]
+        pg: [13, 14, 15, 16, 17, 18]
     container:
       image: pgxn/pgxn-tools
     steps:


### PR DESCRIPTION
This PR adds postgres 18 to the build matrix. Luckily the build passes with no changes, so there's seemingly no extra work to make it compatible 🙂