### PR TITLE
Avoid creating and dropping tables in the test set

### DIFF
--- a/expected/roaringbitmap.out
+++ b/expected/roaringbitmap.out
@@ -2527,9 +2527,8 @@ BEGIN
  END
 $BODY$
 LANGUAGE plpgsql;
-drop table if exists bitmap_test_tb1;
-NOTICE:  table "bitmap_test_tb1" does not exist, skipping
-create table bitmap_test_tb1(id int, bitmap roaringbitmap);
+create table if not exists bitmap_test_tb1(id int, bitmap roaringbitmap);
+truncate bitmap_test_tb1;
 insert into bitmap_test_tb1 values (NULL,NULL);
 insert into bitmap_test_tb1 select id,rb_build(ARRAY[id]) from generate_series(1,10000)id;
 insert into bitmap_test_tb1 values (NULL,NULL);

--- a/sql/roaringbitmap.sql
+++ b/sql/roaringbitmap.sql
@@ -536,8 +536,8 @@ $BODY$
 LANGUAGE plpgsql;
 
 
-drop table if exists bitmap_test_tb1;
-create table bitmap_test_tb1(id int, bitmap roaringbitmap);
+create table if not exists bitmap_test_tb1(id int, bitmap roaringbitmap);
+truncate bitmap_test_tb1;
 insert into bitmap_test_tb1 values (NULL,NULL);
 insert into bitmap_test_tb1 select id,rb_build(ARRAY[id]) from generate_series(1,10000)id;
 insert into bitmap_test_tb1 values (NULL,NULL);


### PR DESCRIPTION
Avoid creating and dropping tables in the test set. 
Repeatedly creating new tables can lead to memory accumulation in CacheMemoryContext, affecting the detection of memory leaks through long-running test sets.