### PR TITLE
Make RunOptimize functions available

### DIFF
--- a/README.md
+++ b/README.md
@@ -929,6 +929,15 @@ or
 2
 3</pre></td>
     </tr>
+    <tr>
+        <td><code>rb64_runoptimize</code></td>
+        <td><code>roaringbitmap64</code></td>
+        <td><code>roaringbitmap64</code></td>
+        <td>Return space-optimized bitmap</td>
+        <td><code>rb64_runoptimize(roaringbitmap64('{1,2,3,4,5}'))</code>
+        <td><code>{1,2,3,4,5}</code>
+(but the underlying bitmap is smaller)</td>
+    </tr>
 </table>
 
 ### Aggregation List

--- a/README.md
+++ b/README.md
@@ -430,6 +430,15 @@ or
 2
 3</pre></td>
     </tr>
+    <tr>
+        <td><code>rb_runoptimize</code></td>
+        <td><code>roaringbitmap</code></td>
+        <td><code>roaringbitmap</code></td>
+        <td>Return space-optimized bitmap</td>
+        <td><code>rb_runoptimize(roaringbitmap('{1,2,3,4,5}'))</code>
+        <td><code>{1,2,3,4,5}</code>
+(but the underlying bitmap is smaller)</td>
+    </tr>
 </table>
 
 ### Aggregation List

--- a/expected/roaringbitmap.out
+++ b/expected/roaringbitmap.out
@@ -944,6 +944,36 @@ select rb_iterate('{1,10,100,2147483647,-2147483648,-1}');
           -1
 (6 rows)
 
+select rb_runoptimize(NULL);
+ rb_runoptimize 
+----------------
+ 
+(1 row)
+
+select rb_runoptimize('{}');
+ rb_runoptimize 
+----------------
+ {}
+(1 row)
+
+select rb_runoptimize('{1}');
+ rb_runoptimize 
+----------------
+ {1}
+(1 row)
+
+select rb_runoptimize('{1,10,100}');
+ rb_runoptimize 
+----------------
+ {1,10,100}
+(1 row)
+
+select rb_runoptimize('{1,10,100,2147483647,-2147483648,-1}');
+            rb_runoptimize            
+--------------------------------------
+ {1,10,100,2147483647,-2147483648,-1}
+(1 row)
+
 -- Test the functions with two bitmap variables
 select rb_and(NULL,'{1,10,100}');
  rb_and 

--- a/expected/roaringbitmap64.out
+++ b/expected/roaringbitmap64.out
@@ -984,6 +984,36 @@ select rb64_iterate('{1,10,100,9223372036854775807,-9223372036854775808,-1}');
                    -1
 (6 rows)
 
+select rb64_runoptimize(NULL);
+ rb64_runoptimize 
+------------------
+ 
+(1 row)
+
+select rb64_runoptimize('{}');
+ rb64_runoptimize 
+------------------
+ {}
+(1 row)
+
+select rb64_runoptimize('{1}');
+ rb64_runoptimize 
+------------------
+ {1}
+(1 row)
+
+select rb64_runoptimize('{1,10,100}');
+ rb64_runoptimize 
+------------------
+ {1,10,100}
+(1 row)
+
+select rb64_runoptimize('{1,10,100,9223372036854775807,-9223372036854775808,-1}');
+                    rb64_runoptimize                    
+--------------------------------------------------------
+ {1,10,100,9223372036854775807,-9223372036854775808,-1}
+(1 row)
+
 -- Test the functions with two bitmap variables
 select rb64_and(NULL,'{1,10,100}');
  rb64_and 

--- a/roaringbitmap--1.1--1.2.sql
+++ b/roaringbitmap--1.1--1.2.sql
@@ -2,3 +2,8 @@ CREATE OR REPLACE FUNCTION rb_runoptimize(roaringbitmap)
   RETURNS roaringbitmap
   AS 'MODULE_PATHNAME', 'rb_runoptimize'
   LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION rb64_runoptimize(roaringbitmap64)
+  RETURNS roaringbitmap64
+  AS 'MODULE_PATHNAME', 'rb64_runoptimize'
+  LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;

--- a/roaringbitmap--1.1--1.2.sql
+++ b/roaringbitmap--1.1--1.2.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE FUNCTION rb_runoptimize(roaringbitmap)
+  RETURNS roaringbitmap
+  AS 'MODULE_PATHNAME', 'rb_runoptimize'
+  LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;

--- a/roaringbitmap--1.2.sql
+++ b/roaringbitmap--1.2.sql
@@ -235,6 +235,11 @@ CREATE OR REPLACE FUNCTION rb_iterate(roaringbitmap)
    AS 'MODULE_PATHNAME', 'rb_iterate'
    LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
 
+CREATE OR REPLACE FUNCTION rb_runoptimize(roaringbitmap)
+  RETURNS roaringbitmap
+  AS 'MODULE_PATHNAME', 'rb_runoptimize'
+  LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
 --
 -- Operators
 --
@@ -740,6 +745,11 @@ CREATE OR REPLACE FUNCTION rb64_iterate(roaringbitmap64)
    RETURNS SETOF bigint
    AS 'MODULE_PATHNAME', 'rb64_iterate'
    LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION rb64_runoptimize(roaringbitmap64)
+  RETURNS roaringbitmap64
+  AS 'MODULE_PATHNAME', 'rb64_runoptimize'
+  LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
 
 --
 -- Operators

--- a/roaringbitmap--1.2.sql
+++ b/roaringbitmap--1.2.sql
@@ -364,7 +364,7 @@ CREATE OPERATOR <> (
 );
 
 --
--- Aggragations
+-- Aggregations
 --
 
 CREATE OR REPLACE FUNCTION rb_final(internal)
@@ -875,7 +875,7 @@ CREATE OPERATOR <> (
 );
 
 --
--- Aggragations
+-- Aggregations
 --
 
 CREATE OR REPLACE FUNCTION rb64_final(internal)

--- a/roaringbitmap.c
+++ b/roaringbitmap.c
@@ -2121,7 +2121,7 @@ rb_runoptimize(PG_FUNCTION_ARGS) {
     roaring_bitmap_t *r;
     size_t expectedsize;
 
-    r = roaring_bitmap_portable_deserialize(VARDATA(serializedbytes));
+    r = roaring_bitmap_portable_deserialize_safe(VARDATA(serializedbytes), VARSIZE(serializedbytes) - VARHDRSZ);
     if (!r)
         ereport(ERROR,
                 (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),

--- a/roaringbitmap.c
+++ b/roaringbitmap.c
@@ -2110,3 +2110,30 @@ rb_cardinality_final(PG_FUNCTION_ARGS) {
         PG_RETURN_INT64(card1);
     }
 }
+
+//bitmap run optimize
+PG_FUNCTION_INFO_V1(rb_runoptimize);
+Datum rb_runoptimize(PG_FUNCTION_ARGS);
+
+Datum
+rb_runoptimize(PG_FUNCTION_ARGS) {
+    bytea *serializedbytes = PG_GETARG_BYTEA_P(0);
+    roaring_bitmap_t *r;
+    size_t expectedsize;
+
+    r = roaring_bitmap_portable_deserialize(VARDATA(serializedbytes));
+    if (!r)
+        ereport(ERROR,
+                (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+                        errmsg("bitmap format is error")));
+
+    roaring_bitmap_run_optimize(r);
+
+    expectedsize = roaring_bitmap_portable_size_in_bytes(r);
+    serializedbytes = (bytea *) palloc(VARHDRSZ + expectedsize);
+    roaring_bitmap_portable_serialize(r, VARDATA(serializedbytes));
+
+    roaring_bitmap_free(r);
+    SET_VARSIZE(serializedbytes, VARHDRSZ + expectedsize);
+    PG_RETURN_BYTEA_P(serializedbytes);
+}

--- a/roaringbitmap.control
+++ b/roaringbitmap.control
@@ -1,5 +1,5 @@
 # roaringbitmap extension
 comment = 'support for Roaring Bitmaps'
-default_version = '1.1'
+default_version = '1.2'
 module_pathname = '$libdir/roaringbitmap'
 relocatable = true

--- a/roaringbitmap64.c
+++ b/roaringbitmap64.c
@@ -2001,3 +2001,30 @@ rb64_cardinality_final(PG_FUNCTION_ARGS) {
         PG_RETURN_INT64(card1);
     }
 }
+
+//bitmap run optimize
+PG_FUNCTION_INFO_V1(rb64_runoptimize);
+Datum rb64_runoptimize(PG_FUNCTION_ARGS);
+
+Datum
+rb64_runoptimize(PG_FUNCTION_ARGS) {
+    bytea *serializedbytes = PG_GETARG_BYTEA_P(0);
+    roaring64_bitmap_t *r;
+    size_t expectedsize;
+
+    r = roaring64_bitmap_portable_deserialize(VARDATA(serializedbytes));
+    if (!r)
+        ereport(ERROR,
+                (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+                        errmsg("bitmap format is error")));
+
+    roaring64_bitmap_run_optimize(r);
+
+    expectedsize = roaring64_bitmap_portable_size_in_bytes(r);
+    serializedbytes = (bytea *) palloc(VARHDRSZ + expectedsize);
+    roaring64_bitmap_portable_serialize(r, VARDATA(serializedbytes));
+
+    roaring64_bitmap_free(r);
+    SET_VARSIZE(serializedbytes, VARHDRSZ + expectedsize);
+    PG_RETURN_BYTEA_P(serializedbytes);
+}

--- a/roaringbitmap64.c
+++ b/roaringbitmap64.c
@@ -2012,7 +2012,7 @@ rb64_runoptimize(PG_FUNCTION_ARGS) {
     roaring64_bitmap_t *r;
     size_t expectedsize;
 
-    r = roaring64_bitmap_portable_deserialize(VARDATA(serializedbytes));
+    r = roaring64_bitmap_portable_deserialize_safe(VARDATA(serializedbytes), VARSIZE(serializedbytes) - VARHDRSZ);
     if (!r)
         ereport(ERROR,
                 (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),

--- a/sql/roaringbitmap.sql
+++ b/sql/roaringbitmap.sql
@@ -208,6 +208,12 @@ select rb_iterate('{1}');
 select rb_iterate('{1,10,100}');
 select rb_iterate('{1,10,100,2147483647,-2147483648,-1}');
 
+select rb_runoptimize(NULL);
+select rb_runoptimize('{}');
+select rb_runoptimize('{1}');
+select rb_runoptimize('{1,10,100}');
+select rb_runoptimize('{1,10,100,2147483647,-2147483648,-1}');
+
 -- Test the functions with two bitmap variables
 
 select rb_and(NULL,'{1,10,100}');

--- a/sql/roaringbitmap64.sql
+++ b/sql/roaringbitmap64.sql
@@ -217,6 +217,12 @@ select rb64_iterate('{1}');
 select rb64_iterate('{1,10,100}');
 select rb64_iterate('{1,10,100,9223372036854775807,-9223372036854775808,-1}');
 
+select rb64_runoptimize(NULL);
+select rb64_runoptimize('{}');
+select rb64_runoptimize('{1}');
+select rb64_runoptimize('{1,10,100}');
+select rb64_runoptimize('{1,10,100,9223372036854775807,-9223372036854775808,-1}');
+
 -- Test the functions with two bitmap variables
 
 select rb64_and(NULL,'{1,10,100}');


### PR DESCRIPTION
This PR makes the `_run_optimize` functions available to the database. This can be useful for reducing database and WAL footprint when making extensive use of roaringbitmaps.

Merging this would presumably warrant an extension version bump, so there's a minimal update file included as `roaringbitmap--1.1--1.2.sql`