### PR TITLE
keep rb_exsit definition for backward compatible with verion less tha…

### DIFF
--- a/roaringbitmap.c
+++ b/roaringbitmap.c
@@ -775,6 +775,16 @@ rb_exists(PG_FUNCTION_ARGS) {
     PG_RETURN_BOOL(isexist);
 }
 
+//rb_exsit is renamed to rb_exists in v1.0
+//keep the old rb_exsit definition for backward compatible
+PG_FUNCTION_INFO_V1(rb_exsit);
+Datum rb_exsit(PG_FUNCTION_ARGS);
+
+Datum
+rb_exsit(PG_FUNCTION_ARGS) {
+    return rb_exists(fcinfo);
+}
+
 //bitmap equals
 PG_FUNCTION_INFO_V1(rb_equals);
 Datum rb_equals(PG_FUNCTION_ARGS);


### PR DESCRIPTION
Function `rb_exsit` is renamed to `rb_exists` in v1.0.

Even though there is an attempt to replace the function definition in `roaringbitmap--0.5--1.0.sql` for migration, it still cause problem if user specifically install with a version less than 1.0 as shown below:

```
postgres=# create extension roaringbitmap with version '0.2';
ERROR:  could not find function "rb_exsit" in file "/opt/homebrew/lib/postgresql@18/roaringbitmap.dylib"
CONTEXT:  SQL statement "CREATE OR REPLACE FUNCTION rb_contains(roaringbitmap, integer)
  RETURNS bool 
  AS '$libdir/roaringbitmap', 'rb_exsit'
  LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE"
extension script file "roaringbitmap--0.2.sql", near line 93
```

This commit retains the definition of `rb_exsit` for backward compatibility that allow user to successfully create roaringbitmap with old version and migrate to newer version without error during installation or runtime.

```
postgres=# create extension roaringbitmap with version '0.2';
CREATE EXTENSION
postgres=# select * from pg_available_extensions where name = 'roaringbitmap';
     name      | default_version | installed_version |           comment           
---------------+-----------------+-------------------+-----------------------------
 roaringbitmap | 1.2             | 0.2               | support for Roaring Bitmaps
(1 row)
```
