### PR TITLE
add postgres19 compatibility

### DIFF
--- a/roaringbitmap.c
+++ b/roaringbitmap.c
@@ -96,7 +96,11 @@ _PG_init(void)
 bool
 ArrayContainsNulls(ArrayType *array) {
     int nelems;
+#if PG_VERSION_NUM >= 190000
+    uint8 *bitmap;
+#else
     bits8 *bitmap;
+#endif
     int bitmask;
 
     /* Easy answer if there's no null bitmap */

--- a/roaringbitmap.c
+++ b/roaringbitmap.c
@@ -96,11 +96,7 @@ _PG_init(void)
 bool
 ArrayContainsNulls(ArrayType *array) {
     int nelems;
-#if PG_VERSION_NUM >= 190000
     uint8 *bitmap;
-#else
-    bits8 *bitmap;
-#endif
     int bitmask;
 
     /* Easy answer if there's no null bitmap */


### PR DESCRIPTION
Fix build with PostgreSQL 19: replace removed bits8 typedef

PostgreSQL 19 removed the bits8 typedef (was an alias for uint8).
Use uint8 on PG19+ with a version guard to maintain backward
compatibility with older PostgreSQL versions.